### PR TITLE
add a 'heightFunc' and 'peek' setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ When calling `$(".navbar-fixed-top").autoHidingNavbar()` you can pass a paramete
 - `showOnBottom`, defaults to `'true'`, the navbar shows up when scroll reaches the page's end.
 - `hideOffset`, defaults to `'auto'`, hides the navbar after scrolling that much pixel. Auto means the navbar's height.
 - `animationDuration`, defaults to `'200'`, is the duration of the show and hide animations in milliseconds.
+- `heightFunc`, defaults to `jQuery.fn.height`, is a reference to a function that calculates the height of the navbar.  `jQuery.fn.outerHeight` is a good choice if your navbar has padding or a border
+- `peek`, defaults to `0`, is a number of pixels of the navbar that should stay visible even when the navbar is hidden
 
 ### Methods
 

--- a/src/jquery.bootstrap-autohidingnavbar.js
+++ b/src/jquery.bootstrap-autohidingnavbar.js
@@ -15,7 +15,9 @@
         showOnUpscroll: true,
         showOnBottom: true,
         hideOffset: 'auto', // "auto" means the navbar height
-        animationDuration: 200
+        animationDuration: 200,
+        heightFunc: $.fn.height, // a function to calculate the height of the navbar.  another good option is $.fn.outerHeight
+        peek: 0 // how much the navbar should "peek" out while hidden.  provide a positive number of pixels.
       };
 
   function AutoHidingNavbar(element, options) {
@@ -32,7 +34,7 @@
     }
 
     autoHidingNavbar.element.addClass('navbar-hidden').animate({
-      top: -autoHidingNavbar.element.height()
+      top: -autoHidingNavbar.settings.heightFunc.call(autoHidingNavbar.element, autoHidingNavbar.element) + autoHidingNavbar.settings.peek
     }, {
       queue: false,
       duration: autoHidingNavbar.settings.animationDuration
@@ -136,7 +138,7 @@
       this.setHideOffset(this.settings.hideOffset);
       this.setAnimationDuration(this.settings.animationDuration);
 
-      _hideOffset = this.settings.hideOffset === 'auto' ? this.element.height() : this.settings.hideOffset;
+      _hideOffset = this.settings.hideOffset === 'auto' ? this.settings.heightFunc.call(this.element) : this.settings.hideOffset;
       bindEvents(this);
 
       return this.element;


### PR DESCRIPTION
I added two settings for my own use and figured I'd offer them up in case they're useful for anyone else.

autoHidingNavbar uses jQuery's [height](http://api.jquery.com/height/) function to find the height of the navbar.  Our navbar has padding, though, which `height` doesn't take into account.  jQuery's [`outerHeight`](http://api.jquery.com/outerHeight/) is needed when padding, border, or margin need to be included in the height calculation.

In order to make it flexible, I added a `heightFunc` option that accepts any height-calculating function.

Here's an example of using heightFunc to specify jQuery's `outerHeight` function.

```
header_nav.autoHidingNavbar({
    heightFunc  : $.fn.outerHeight,
    peek        : 2
});
```

Or with a custom function:

```
function getHeight(el) {
    return el.height; // some custom height-finding math
}

header_nav.autoHidingNavbar({
    heightFunc  : getHeight,
    peek        : 2
});
```

The `peek` parameter there is an option that allows the navbar to stay partially visible even when "hidden".  On some sites, designers like to leave a tiny sliver of the navbar visible, just to remind the user that it's there.  This way it doesn't disappear completely when hidden.

A peek value of `2` makes 2px worth of the navbar "peek" out from under the viewport.

The default value for heightFunc is still `$.fn.height` and the default for peek is 0, so this should be completely backwards-compatible.

I added the options to the README in this PR.  If there's any other work you'd like me to do, let me know.  Or if this isn't something you're interested in, that's okay too!
