### PR TITLE
cancel any pending animations when a new one starts

### DIFF
--- a/src/jquery.bootstrap-autohidingnavbar.js
+++ b/src/jquery.bootstrap-autohidingnavbar.js
@@ -31,7 +31,7 @@
       return;
     }
 
-    autoHidingNavbar.element.addClass('navbar-hidden').animate({
+    autoHidingNavbar.element.addClass('navbar-hidden').stop().animate({
       top: -autoHidingNavbar.element.height()
     }, {
       queue: false,
@@ -48,7 +48,7 @@
       return;
     }
 
-    autoHidingNavbar.element.removeClass('navbar-hidden').animate({
+    autoHidingNavbar.element.removeClass('navbar-hidden').stop().animate({
       top: 0
     }, {
       queue: false,


### PR DESCRIPTION
I think it's good practice to use jQuery's [`stop`](http://api.jquery.com/stop/) to cancel any current/pending animations before starting a new animation.  It keeps them from stacking.

I honestly didn't do any testing before adding this, so I don't know how much benefit it provides, but here it is anyway! :)
