### PR TITLE
Adds the ability to hide() after a specific delay when reading the page

### DIFF
--- a/demo/indexWithDelay.html
+++ b/demo/indexWithDelay.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>Auto-hiding fixed navbar for Bootstrap</title>
+
+    <link href="http://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.1.1/css/bootstrap.min.css" rel="stylesheet">
+
+    <style>
+      .demo-long {
+        margin-top: 100px;
+        margin-bottom: 200px;
+      }
+    </style>
+  </head>
+
+  <body>
+
+    <div class="navbar navbar-default navbar-fixed-top" role="navigation">
+      <div class="container">
+        <div class="navbar-header">
+          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <a class="navbar-brand" href="#">Auto hiding navbar</a>
+        </div>
+        <div class="navbar-collapse collapse">
+          <ul class="nav navbar-nav">
+            <li class="active"><a href="#">Home</a></li>
+            <li><a href="#about">About</a></li>
+            <li><a href="#contact">Contact</a></li>
+            <li class="dropdown">
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown">Dropdown <b class="caret"></b></a>
+              <ul class="dropdown-menu">
+                <li><a href="#">Action</a></li>
+                <li><a href="#">Another action</a></li>
+                <li><a href="#">Something else here</a></li>
+                <li class="divider"></li>
+                <li class="dropdown-header">Nav header</li>
+                <li><a href="#">Separated link</a></li>
+                <li><a href="#">One more separated link</a></li>
+              </ul>
+            </li>
+          </ul>
+          <ul class="nav navbar-nav navbar-right">
+            <li><a href="#">Default</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <div class="container">
+
+      <p class="demo-long">
+        Long content...
+      </p>
+      <p class="demo-long">
+        Long content...
+      </p>
+      <p class="demo-long">
+        Long content...
+      </p>
+      <p class="demo-long">
+        Long content...
+      </p>
+      <p class="demo-long">
+        Long content...
+      </p>
+      <p class="demo-long">
+        Long content...
+      </p>
+
+    </div>
+
+    <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+    <script src="http://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.1.1/js/bootstrap.min.js"></script>
+
+    <script src="../src/jquery.bootstrap-autohidingnavbar.js"></script>
+
+    <script>
+      $("div.navbar-fixed-top").autoHidingNavbar({hideAfter:5000});
+    </script>

--- a/src/jquery.bootstrap-autohidingnavbar.js
+++ b/src/jquery.bootstrap-autohidingnavbar.js
@@ -9,13 +9,15 @@
       _previousScrollTop = null,
       _windowHeight = $window.height(),
       _visible = true,
+      _timeoutID = null,
       _hideOffset,
       defaults = {
         disableAutohide: false,
         showOnUpscroll: true,
         showOnBottom: true,
         hideOffset: 'auto', // "auto" means the navbar height
-        animationDuration: 200
+        animationDuration: 200,
+        hideAfter: 0 //0 means delayed hide not active
       };
 
   function AutoHidingNavbar(element, options) {
@@ -54,6 +56,12 @@
       queue: false,
       duration: autoHidingNavbar.settings.animationDuration
     });
+    if(autoHidingNavbar.settings.hideAfter > 0) {
+      if(_timeoutID != null){
+        window.clearTimeout(_timeoutID);
+      }
+      _timeoutID = window.setTimeout(hide, autoHidingNavbar.settings.hideAfter, autoHidingNavbar);
+    }
     _visible = true;
   }
 


### PR DESCRIPTION
Adds the ability to call the hide() methods after a customizable number of ms after the autoHidingElement is shown in order to allow having the fullscreen when the scrollUp is fired "by mistake".

The same functionality is not called on page load but only when show() is called.

A test page is provided.
