### PR TITLE
fix description. It shouldn't be over 140 characters

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/istvan-ujjmeszaros"
     }
 	],
-	"description": "An extension for Bootstrap's fixed navbar which hides the navbar while the page is scrolling downwards and shows it the other way. The plugin is able to show/hide the navbar programmatically as well.",
+	"description": "An extension for Bootstrap's fixed navbar which hides the navbar while the page is scrolling downwards and shows it the other way.",
 	"main": "src/jquery.bootstrap-autohidingnavbar.js",
   "dependencies": {
     "jquery": ">=1.9.0",


### PR DESCRIPTION
> bower bootstrap-autohidingnavbar#1.0.0         EINVALID Failed to read /var/folders/1t/y1l91wl10c1dzz3682wqvnxh0000gn/T/moi/bower/bootstrap-autohidingnavbar-4994-qIJiEh/bower.json
> 
> Additional error details:
> The description is too long. 140 characters should be more than enough

https://github.com/bower/bower.json-spec#description