### PR TITLE
Trigger events when navbar is hidden or shown

### DIFF
--- a/src/jquery.bootstrap-autohidingnavbar.js
+++ b/src/jquery.bootstrap-autohidingnavbar.js
@@ -41,6 +41,8 @@
     $('.dropdown.open .dropdown-toggle', autoHidingNavbar.element).dropdown('toggle');
 
     _visible = false;
+
+	autoHidingNavbar.element.trigger('hide.autoHidingNavbar');
   }
 
   function show(autoHidingNavbar) {
@@ -55,6 +57,8 @@
       duration: autoHidingNavbar.settings.animationDuration
     });
     _visible = true;
+
+	autoHidingNavbar.element.trigger('show.autoHidingNavbar');
   }
 
   function detectState(autoHidingNavbar) {


### PR DESCRIPTION
A hide event is fired after hiding the navbar, and a show event is fired after showing it. You can then add the custom handlers like this:

```javascript
	$(document).on('show.autoHidingNavbar',function(){
		console.log('hello');
	});
```

Or like this:

```javascript
	$('.navbar-fixed').on('hide.autoHidingNavbar',function(){
		console.log('bye');
	});
```

I decided to use 'autoHidingNavbar' namespace but feel free to change it to whatever you think is best!