### PR TITLE
Changed invalid Apache license name to correct form.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,5 +21,5 @@
 		"ui",
 		"navigation"
 	],
-	"license": "Apache License v2.0"
+	"license": "Apache-2.0"
 }

--- a/package.json
+++ b/package.json
@@ -24,5 +24,9 @@
   },
   "scripts": {
     "test": "grunt travis --verbose"
-  }
+  },
+  "licenses": [{
+    "type": "Apache-2.0",
+    "url": "http://www.apache.org/licenses/LICENSE-2.0"
+  }]
 }


### PR DESCRIPTION
Could not add your repo in webjars.org, got: 

"Failed! No valid licenses found. Detected licenses: Apache License v2.0 The acceptable licenses on BinTray are at: https://bintray.com/docs/api/#_footnote_1 License detection first uses the package metadata".