### PR TITLE
Fix not hidding when navbar has an expanded dropdown

### DIFF
--- a/src/jquery.bootstrap-autohidingnavbar.js
+++ b/src/jquery.bootstrap-autohidingnavbar.js
@@ -27,7 +27,7 @@
   }
 
   function hide(autoHidingNavbar) {
-    if (!_visible) {
+    if (!_visible || autoHidingNavbar.element.find('.navbar-collapse').hasClass('in')) {
       return;
     }
 


### PR DESCRIPTION
The case is on a navbar with a dropdown element in it, which is expanded.  Once you scroll to the bottom of it on mobile, it  starts to scroll the page itself, therefore it hides the navbar, which is kinda odd.

Now, if there's an expanded dropdown the navbar remains visible.