### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Bootstrap Auto-Hiding Navbar [![Build Status](https://secure.travis-ci.org/istvan-ujjmeszaros/bootstrap-autohidingnavbar.png?branch=master)](https://travis-ci.org/istvan-ujjmeszaros/bootstrap-autohidingnavbar)
 Bootstrap Auto-Hiding Navbar is an extension for Bootstrap's fixed navbar which hides the navbar while the page is scrolling downwards and shows it the other way. The plugin is able to show/hide the navbar programmatically as well.
 
-##Demo
+## Demo
 
 [http://www.virtuosoft.eu/code/bootstrap-autohidingnavbar/](http://www.virtuosoft.eu/code/bootstrap-autohidingnavbar/)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
